### PR TITLE
[fix/33-letter-transmission-interval] 편지 전송 간격 설정

### DIFF
--- a/unibond/src/main/java/com/unibond/unibond/UnibondApplication.java
+++ b/unibond/src/main/java/com/unibond/unibond/UnibondApplication.java
@@ -3,13 +3,15 @@ package com.unibond.unibond;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class UnibondApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(UnibondApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(UnibondApplication.class, args);
+    }
 
 }

--- a/unibond/src/main/java/com/unibond/unibond/common/BaseEntity.java
+++ b/unibond/src/main/java/com/unibond/unibond/common/BaseEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicInsert;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -17,6 +18,7 @@ import static jakarta.persistence.EnumType.STRING;
 
 @Getter
 @MappedSuperclass
+@DynamicInsert
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
@@ -29,5 +31,6 @@ public class BaseEntity {
 
     @Enumerated(STRING)
     @Setter
-    private BaseEntityStatus status = ACTIVE;
+    @Column(columnDefinition = "VARCHAR(255) DEFAULT 'ACTIVE'")
+    private BaseEntityStatus status;
 }

--- a/unibond/src/main/java/com/unibond/unibond/common/BaseResponseStatus.java
+++ b/unibond/src/main/java/com/unibond/unibond/common/BaseResponseStatus.java
@@ -68,6 +68,8 @@ public enum BaseResponseStatus {
     // letter (3300 ~ 3399)
     NOT_ENOUGH_CHARS(false, 3300, "편지는 최소 50자 이상이어야 합니다."),
     NOT_YOUR_LETTER(false, 3301, "해당 편지를 접근할 권한이 없습니다."),
+    CANT_SEND_LETTER(false, 3302, "아직 한 시간이 지나지 않았으므로 편지를 또 다시 보낼 수 없습니다."),
+    NOT_YET_ARRIVED(false, 3303, "아직 도착하지 않은 편지입니다."),
 
     // letter_room (3400 ~ 3499)
     NOT_YOUR_LETTER_ROOM(false, 3400, "해당 편지방에 접근할 권한이 없습니다."),

--- a/unibond/src/main/java/com/unibond/unibond/letter/domain/Letter.java
+++ b/unibond/src/main/java/com/unibond/unibond/letter/domain/Letter.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDateTime;
 
@@ -18,6 +19,7 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@DynamicInsert
 @NoArgsConstructor(access = PROTECTED)
 public class Letter extends BaseEntity {
 
@@ -47,7 +49,7 @@ public class Letter extends BaseEntity {
 
     @Enumerated(STRING)
     @Setter
-    @Column(columnDefinition = "varchar(10) default 'SENDING'")
+    @Column(columnDefinition = "VARCHAR(255) DEFAULT 'SENDING'")
     private LetterStatus letterStatus;
 
     @Builder

--- a/unibond/src/main/java/com/unibond/unibond/letter/domain/Letter.java
+++ b/unibond/src/main/java/com/unibond/unibond/letter/domain/Letter.java
@@ -1,6 +1,8 @@
 package com.unibond.unibond.letter.domain;
 
 import com.unibond.unibond.common.BaseEntity;
+import com.unibond.unibond.common.BaseException;
+import com.unibond.unibond.common.BaseResponseStatus;
 import com.unibond.unibond.letter_room.domain.LetterRoom;
 import com.unibond.unibond.member.domain.Member;
 import jakarta.persistence.*;
@@ -12,6 +14,7 @@ import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDateTime;
 
+import static com.unibond.unibond.letter.domain.LetterStatus.*;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -68,5 +71,19 @@ public class Letter extends BaseEntity {
 
     public LocalDateTime getArrivalDate() {
         return this.getCreatedDate().plusHours(1);
+    }
+
+    public void checkIsArrived() throws BaseException {
+        if (this.letterStatus.equals(SENDING)) {
+            throw new BaseException(BaseResponseStatus.NOT_YET_ARRIVED);
+        }
+    }
+
+    public Boolean isSender(Long senderId) {
+        return this.sender.getId().equals(senderId);
+    }
+
+    public Boolean isReceiver(Long receiverId) {
+        return this.receiver.getId().equals(receiverId);
     }
 }

--- a/unibond/src/main/java/com/unibond/unibond/letter/repository/LetterRepository.java
+++ b/unibond/src/main/java/com/unibond/unibond/letter/repository/LetterRepository.java
@@ -5,11 +5,11 @@ import com.unibond.unibond.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -33,4 +33,9 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
             "order by l.createdDate desc")
     Page<Letter> findLettersByLetterRoomAndReceiverOrSender(@Param("letterRoom") Long letterRoomId,
                                                             @Param("participant") Long participantId, Pageable pageable);
+
+    @Modifying
+    @Query("update Letter l set l.letterStatus = 'ARRIVED' " +
+            "where (FUNCTION('DATE_ADD', l.createdDate, 1, 'HOUR') <= CURRENT_TIMESTAMP) and l.letterStatus = 'SENDING'")
+    void bulkSendLetter();
 }

--- a/unibond/src/main/java/com/unibond/unibond/letter/service/LetterScheduler.java
+++ b/unibond/src/main/java/com/unibond/unibond/letter/service/LetterScheduler.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class LetterScheduler {
@@ -14,6 +16,6 @@ public class LetterScheduler {
     @Transactional
     @Scheduled(cron = "0 0/30 * * * *")
     public void sendLetter() {
-        letterRepository.bulkSendLetter();
+        letterRepository.bulkSendLetter(LocalDateTime.now().minusHours(1L));
     }
 }

--- a/unibond/src/main/java/com/unibond/unibond/letter/service/LetterScheduler.java
+++ b/unibond/src/main/java/com/unibond/unibond/letter/service/LetterScheduler.java
@@ -14,7 +14,7 @@ public class LetterScheduler {
     private final LetterRepository letterRepository;
 
     @Transactional
-    @Scheduled(cron = "0 0/30 * * * *")
+    @Scheduled(cron = "0 0,30 * * * *")
     public void sendLetter() {
         letterRepository.bulkSendLetter(LocalDateTime.now().minusHours(1L));
     }

--- a/unibond/src/main/java/com/unibond/unibond/letter/service/LetterScheduler.java
+++ b/unibond/src/main/java/com/unibond/unibond/letter/service/LetterScheduler.java
@@ -1,0 +1,19 @@
+package com.unibond.unibond.letter.service;
+
+import com.unibond.unibond.letter.repository.LetterRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LetterScheduler {
+    private final LetterRepository letterRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0/30 * * * *")
+    public void sendLetter() {
+        letterRepository.bulkSendLetter();
+    }
+}

--- a/unibond/src/main/java/com/unibond/unibond/letter_room/service/LetterRoomService.java
+++ b/unibond/src/main/java/com/unibond/unibond/letter_room/service/LetterRoomService.java
@@ -47,15 +47,6 @@ public class LetterRoomService {
         }
     }
 
-    private Member findAnotherParticipant(Letter letter, Long loginId) throws BaseException {
-        if (letter.getSender().getId().equals(loginId)) {
-            return letter.getReceiver();
-        } else if (letter.getReceiver().getId().equals(loginId)) {
-            return letter.getSender();
-        }
-        throw new BaseException(NOT_YOUR_LETTER_ROOM);
-    }
-
     public GetAllLetterRoomsResDto getAllLetterRooms(Pageable pageable) throws BaseException {
         try {
             Long loginMemberId = loginInfoService.getLoginMemberId();
@@ -65,5 +56,14 @@ public class LetterRoomService {
             System.out.println(e);
             throw new BaseException(DATABASE_ERROR);
         }
+    }
+
+    private Member findAnotherParticipant(Letter letter, Long loginId) throws BaseException {
+        if (letter.getSender().getId().equals(loginId)) {
+            return letter.getReceiver();
+        } else if (letter.getReceiver().getId().equals(loginId)) {
+            return letter.getSender();
+        }
+        throw new BaseException(NOT_YOUR_LETTER_ROOM);
     }
 }


### PR DESCRIPTION
## 📒 개요

내용을 적어주세요.

## 📍 Issue 번호

> #33 

## 🛠️ 작업사항

-  30분마다 배치를 돌리며 보낸지 한시간이 지난 편지들을 SENDING 상태에서 자동으로 ARRIVED 상태로 변경되도록 설정한다.
- 1시간 이내에 같은 수신자에게 연속적인 편지 전송 막는다
- 편지 조회, 편지 좋아요 등등은 letterStatus가 ARRIVED일 경우에만 열람이 가능하도록 하였다.
  - 참고로 전송 중인 편지는 송신자만 보이게 설정함. 
