### PR TITLE
[feature/61-block-letter-and-letterroom] 편지와 편지함 차단 API

### DIFF
--- a/unibond/BOOT-INF/classes/static/docs/experience-community.html
+++ b/unibond/BOOT-INF/classes/static/docs/experience-community.html
@@ -454,10 +454,16 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_response">Response</a></li>
 </ul>
 </li>
-<li><a href="#_upload_posts_on_experience_community">Upload Posts on Experience Community</a>
+<li><a href="#_upload_posts_on_experience_community_v1">Upload Posts on Experience Community- V1</a>
 <ul class="sectlevel2">
 <li><a href="#_request_2">Request</a></li>
 <li><a href="#_response_2">Response</a></li>
+</ul>
+</li>
+<li><a href="#_upload_posts_on_experience_community_v2">Upload Posts on Experience Community- V2</a>
+<ul class="sectlevel2">
+<li><a href="#_request_3">Request</a></li>
+<li><a href="#_response_3">Response</a></li>
 </ul>
 </li>
 </ul>
@@ -523,7 +529,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 2451
+Content-Length: 3082
 
 {
   "isSuccess" : true,
@@ -531,13 +537,24 @@ Content-Length: 2451
   "message" : "요청에 성공하였습니다.",
   "result" : {
     "pageInfo" : {
-      "numberOfElements" : 3,
+      "numberOfElements" : 4,
       "lastPage" : true,
       "totalPages" : 1,
-      "totalElements" : 3,
+      "totalElements" : 4,
       "size" : 30
     },
     "postPreviewList" : [ {
+      "createdDate" : "2024-01-05T00:08:44.564552",
+      "ownerId" : 32,
+      "ownerProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/0ee1ae29-e205-4107-9a4d-69ffa68e98ecmountaineers-5649828_640.jpg",
+      "ownerNick" : "건강렛츠고",
+      "disease" : "종양 괴사 인자 수용체와 관련된 주기성 증후군",
+      "postId" : 100,
+      "postImg" : null,
+      "contentPreview" : "전 정말 운동을 하면 할 수록 건강해지는 느낌이라 너무 좋습니다\uD83D\uDCAA\uD83C\uDFFB 다들 기분",
+      "boardType" : "EXPERIENCE",
+      "isEnd" : false
+    }, {
       "createdDate" : "2024-01-03T01:30:08.746334",
       "ownerId" : 27,
       "ownerProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/ef3a45d1-4eb3-48a5-af19-92b0b42aee2bnight-1927265_640.jpg",
@@ -549,14 +566,14 @@ Content-Length: 2451
       "boardType" : "EXPERIENCE",
       "isEnd" : false
     }, {
-      "createdDate" : "2024-01-03T01:13:39.116094",
+      "createdDate" : "2024-01-03T01:13:39.116",
       "ownerId" : 32,
       "ownerProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/0ee1ae29-e205-4107-9a4d-69ffa68e98ecmountaineers-5649828_640.jpg",
       "ownerNick" : "건강렛츠고",
       "disease" : "종양 괴사 인자 수용체와 관련된 주기성 증후군",
       "postId" : 63,
       "postImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/post/4a57410a-75e4-40bb-9724-73d111dc8db5KakaoTalk_20240103_010050997.jpg",
-      "contentPreview" : "아무리 환자라도 공부할 건 해아죠ㅋㅋ\uD83D\uDE31 다들 시험 별로 안남으셨을 텐데 공부 잘",
+      "contentPreview" : "아무리 환자라도 공부할 건 해야겠죠..\uD83D\uDE34\uD83D\uDE34 다들 시험 별로 안 남으셨을 텐데 ",
       "boardType" : "EXPERIENCE",
       "isEnd" : false
     }, {
@@ -700,16 +717,127 @@ Content-Length: 2451
 </div>
 </div>
 <div class="sect1">
-<h2 id="_upload_posts_on_experience_community"><a class="link" href="#_upload_posts_on_experience_community">Upload Posts on Experience Community</a></h2>
+<h2 id="_upload_posts_on_experience_community_v1"><a class="link" href="#_upload_posts_on_experience_community_v1">Upload Posts on Experience Community- V1</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>경험 기록 게시판에 게시물 업로드하기</p>
+<p>경험 기록 게시판에 게시물 업로드하기 (v1)</p>
 </div>
 <div class="sect2">
 <h3 id="_request_2"><a class="link" href="#_request_2">Request</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ http --multipart POST 'http://localhost:8080/api/v1/community/experience' \
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/community/experience HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: 29
+Accept: application/json
+Content-Length: 103
+Host: localhost:8080
+
+{
+  "content" : "안녕하세요 경험 공유 게시판 게시물을 업로드해보겠습니다."
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Basic auth credentials</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">경험 공유 게시판에 업로드 할 게시물의 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_response_2"><a class="link" href="#_response_2">Response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 95
+
+{
+  "isSuccess" : true,
+  "code" : 1000,
+  "message" : "요청에 성공하였습니다."
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isSuccess</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_upload_posts_on_experience_community_v2"><a class="link" href="#_upload_posts_on_experience_community_v2">Upload Posts on Experience Community- V2</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>경험 기록 게시판에 게시물 업로드하기 (v2)</p>
+</div>
+<div class="sect2">
+<h3 id="_request_3"><a class="link" href="#_request_3">Request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ http --multipart POST 'http://localhost:8080/api/v2/community/experience' \
     'Authorization:29' \
     'postImg'@'test-img.jpg' \
     'request'@'request'</code></pre>
@@ -717,7 +845,7 @@ Content-Length: 2451
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/api/v1/community/experience' -i -X POST \
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/api/v2/community/experience' -i -X POST \
     -H 'Content-Type: multipart/form-data;charset=UTF-8' \
     -H 'Authorization: 29' \
     -F 'postImg=@test-img.jpg;type=multipart/form-data' \
@@ -801,7 +929,7 @@ Content-Length: 2451
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_2"><a class="link" href="#_response_2">Response</a></h3>
+<h3 id="_response_3"><a class="link" href="#_response_3">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
@@ -853,7 +981,7 @@ Content-Length: 95
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-08 21:14:50 +0900
+Last updated 2024-01-09 20:21:59 +0900
 </div>
 </div>
 </body>

--- a/unibond/BOOT-INF/classes/static/docs/letter-rooms.html
+++ b/unibond/BOOT-INF/classes/static/docs/letter-rooms.html
@@ -519,17 +519,17 @@ Content-Length: 1599
   "message" : "요청에 성공하였습니다.",
   "result" : {
     "letterRoomList" : [ {
+      "senderProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/3b6fc68f-808c-4e22-97e8-9447d6916bc5cat-2068462_640.jpg",
+      "senderNick" : "눈송이네 베이킹",
+      "senderId" : 30,
+      "recentLetterSentDate" : "2024-01-09T02:30:19.901808",
+      "letterRoomId" : 19
+    }, {
       "senderProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/025cc515-c832-4c29-9fe0-9e77f0afea7d6808929_emoji_emoticon_emotion_expression_face_icon.png",
       "senderNick" : "서울의가을",
       "senderId" : 28,
       "recentLetterSentDate" : "2024-01-08T19:33:37.078678",
       "letterRoomId" : 12
-    }, {
-      "senderProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/3b6fc68f-808c-4e22-97e8-9447d6916bc5cat-2068462_640.jpg",
-      "senderNick" : "눈송이네 베이킹",
-      "senderId" : 30,
-      "recentLetterSentDate" : "2024-01-07T22:56:25.129518",
-      "letterRoomId" : 19
     }, {
       "senderProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/ef3a45d1-4eb3-48a5-af19-92b0b42aee2bnight-1927265_640.jpg",
       "senderNick" : "찍사",

--- a/unibond/BOOT-INF/classes/static/docs/member.html
+++ b/unibond/BOOT-INF/classes/static/docs/member.html
@@ -500,7 +500,7 @@ Host: localhost:8080
 
 {
   "diseaseId" : 1,
-  "diseaseTiming" : "2024-01-08",
+  "diseaseTiming" : "2024-01-09",
   "gender" : "FEMALE",
   "nickname" : "안녕하세요닉네임",
   "bio" : "안녕하세요 한 줄 소개 작성합니다.",
@@ -563,7 +563,7 @@ Host: localhost:8080
   "isSuccess" : true,
   "code" : 1000,
   "message" : "요청에 성공하였습니다.",
-  "result" : 68
+  "result" : 75
 }</code></pre>
 </div>
 </div>
@@ -690,7 +690,7 @@ Host: localhost:8080</code></pre>
     "profileImage" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/f4113115-ee23-4a14-8a47-861b5aa7fdecdog-4586317_640.jpg",
     "nickname" : "병원장",
     "gender" : "MALE",
-    "diseaseName" : "포도당 수송자 1 결핍증",
+    "diseaseName" : "피어슨 증후군[Pierson syndrome]",
     "diagnosisTiming" : "2002-06-27",
     "bio" : "새로운 신약 병원 정보 환영합니다.",
     "interestList" : [ "유전자", "문화생활", "복지", "운동" ]
@@ -856,23 +856,34 @@ Host: localhost:8080</code></pre>
     "profileImage" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/f4113115-ee23-4a14-8a47-861b5aa7fdecdog-4586317_640.jpg",
     "nickname" : "병원장",
     "gender" : "MALE",
-    "diseaseName" : "포도당 수송자 1 결핍증",
+    "diseaseName" : "피어슨 증후군[Pierson syndrome]",
     "diagnosisTiming" : "2002-06-27",
     "bio" : "새로운 신약 병원 정보 환영합니다.",
     "interestList" : [ "유전자", "문화생활", "복지", "운동" ],
     "pageInfo" : {
-      "numberOfElements" : 1,
+      "numberOfElements" : 2,
       "lastPage" : true,
       "totalPages" : 1,
-      "totalElements" : 1,
+      "totalElements" : 2,
       "size" : 30
     },
     "postPreviewList" : [ {
+      "createdDate" : "2024-01-08T02:18:05.209",
+      "ownerId" : 29,
+      "ownerProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/f4113115-ee23-4a14-8a47-861b5aa7fdecdog-4586317_640.jpg",
+      "ownerNick" : "병원장",
+      "disease" : "피어슨 증후군[Pierson syndrome]",
+      "postId" : 103,
+      "postImg" : null,
+      "contentPreview" : "qna test",
+      "boardType" : "QNA",
+      "isEnd" : true
+    }, {
       "createdDate" : "2023-12-30T00:40:29.237761",
       "ownerId" : 29,
       "ownerProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/f4113115-ee23-4a14-8a47-861b5aa7fdecdog-4586317_640.jpg",
       "ownerNick" : "병원장",
-      "disease" : "포도당 수송자 1 결핍증",
+      "disease" : "피어슨 증후군[Pierson syndrome]",
       "postId" : 60,
       "postImg" : null,
       "contentPreview" : "급하게 친구들끼리 여행을 가게 될 일이 생겼어요. 사실 이동하는 게 많이 어려워서",
@@ -1436,7 +1447,7 @@ Content-Length: 564
   "code" : 1000,
   "message" : "요청에 성공하였습니다.",
   "result" : {
-    "profileImage" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/00f348b2-0669-4007-a6ff-6e4129b71023test_profile_img.jpg",
+    "profileImage" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/2e8f7688-1c73-45da-b3b3-fa6189ec8f35test_profile_img.jpg",
     "nickname" : "병원장",
     "gender" : "MALE",
     "diseaseName" : "1번 염색체 장완 21.3 부분의 미세결손 증후군",

--- a/unibond/BOOT-INF/classes/static/docs/question-community.html
+++ b/unibond/BOOT-INF/classes/static/docs/question-community.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.10">
 <meta name="author" content="Lucy Oh">
-<title>Experience Community API</title>
+<title>Q&amp;A Community API</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -440,7 +440,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body class="book toc2 toc-left">
 <div id="header">
-<h1>Experience Community API</h1>
+<h1>Q&amp;A Community API</h1>
 <div class="details">
 <span id="author" class="author">Lucy Oh</span><br>
 <span id="revnumber">version 0.0.1-SNAPSHOT</span>
@@ -517,7 +517,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 2067
+Content-Length: 4369
 
 {
   "isSuccess" : true,
@@ -525,18 +525,62 @@ Content-Length: 2067
   "message" : "요청에 성공하였습니다.",
   "result" : {
     "pageInfo" : {
-      "numberOfElements" : 3,
+      "numberOfElements" : 7,
       "lastPage" : true,
       "totalPages" : 1,
-      "totalElements" : 3,
+      "totalElements" : 7,
       "size" : 30
     },
     "postPreviewList" : [ {
+      "createdDate" : "2024-01-08T02:18:05.209",
+      "ownerId" : 29,
+      "ownerProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/f4113115-ee23-4a14-8a47-861b5aa7fdecdog-4586317_640.jpg",
+      "ownerNick" : "병원장",
+      "disease" : "피어슨 증후군[Pierson syndrome]",
+      "postId" : 103,
+      "postImg" : null,
+      "contentPreview" : "qna test",
+      "boardType" : "QNA",
+      "isEnd" : true
+    }, {
+      "createdDate" : "2024-01-08T00:19:00.317",
+      "ownerId" : 32,
+      "ownerProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/0ee1ae29-e205-4107-9a4d-69ffa68e98ecmountaineers-5649828_640.jpg",
+      "ownerNick" : "건강렛츠고",
+      "disease" : "종양 괴사 인자 수용체와 관련된 주기성 증후군",
+      "postId" : 102,
+      "postImg" : null,
+      "contentPreview" : "처음엔 주위 반응을 봐도 덤덤했는데 점점 힘들어지는 것 같아요. 특히 처음 자기 ",
+      "boardType" : "QNA",
+      "isEnd" : false
+    }, {
+      "createdDate" : "2024-01-07T00:13:08.229315",
+      "ownerId" : 32,
+      "ownerProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/0ee1ae29-e205-4107-9a4d-69ffa68e98ecmountaineers-5649828_640.jpg",
+      "ownerNick" : "건강렛츠고",
+      "disease" : "종양 괴사 인자 수용체와 관련된 주기성 증후군",
+      "postId" : 101,
+      "postImg" : null,
+      "contentPreview" : "오늘 계속 병에 대해 찾아봤는데 임상시험 얘기가 계속 나오네요... 혹시 참여해보",
+      "boardType" : "QNA",
+      "isEnd" : false
+    }, {
+      "createdDate" : "2024-01-04T00:06:24.452238",
+      "ownerId" : 32,
+      "ownerProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/0ee1ae29-e205-4107-9a4d-69ffa68e98ecmountaineers-5649828_640.jpg",
+      "ownerNick" : "건강렛츠고",
+      "disease" : "종양 괴사 인자 수용체와 관련된 주기성 증후군",
+      "postId" : 99,
+      "postImg" : null,
+      "contentPreview" : "혹시 여기 외국에 거주하고 계신 분도 있으신가요?\uD83D\uDE32 전 호주에서 거주하고 있는데",
+      "boardType" : "QNA",
+      "isEnd" : false
+    }, {
       "createdDate" : "2023-12-30T00:40:29.237761",
       "ownerId" : 29,
       "ownerProfileImg" : "https://unibond-img-bucket.s3.ap-northeast-2.amazonaws.com/user/f4113115-ee23-4a14-8a47-861b5aa7fdecdog-4586317_640.jpg",
       "ownerNick" : "병원장",
-      "disease" : "포도당 수송자 1 결핍증",
+      "disease" : "피어슨 증후군[Pierson syndrome]",
       "postId" : 60,
       "postImg" : null,
       "contentPreview" : "급하게 친구들끼리 여행을 가게 될 일이 생겼어요. 사실 이동하는 게 많이 어려워서",
@@ -697,7 +741,7 @@ Content-Length: 2067
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-08 21:14:50 +0900
+Last updated 2024-01-09 20:19:49 +0900
 </div>
 </div>
 </body>

--- a/unibond/src/main/java/com/unibond/unibond/block/controller/BlockController.java
+++ b/unibond/src/main/java/com/unibond/unibond/block/controller/BlockController.java
@@ -42,4 +42,24 @@ public class BlockController {
             return new BaseResponse<>(e.getStatus());
         }
     }
+
+    @PostMapping("/letter")
+    public BaseResponse<?> blockLetter(@RequestHeader("Authorization") Long loginId,
+                                        @RequestBody BlockReqDto reqDto) {
+        try {
+            return new BaseResponse<>(blockService.blockLetter(reqDto));
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    @PostMapping("/comment")
+    public BaseResponse<?> blockLetterRoom(@RequestHeader("Authorization") Long loginId,
+                                        @RequestBody BlockReqDto reqDto) {
+        try {
+            return new BaseResponse<>(blockService.blockLetterRoom(reqDto));
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
 }

--- a/unibond/src/main/java/com/unibond/unibond/block/controller/BlockController.java
+++ b/unibond/src/main/java/com/unibond/unibond/block/controller/BlockController.java
@@ -53,7 +53,7 @@ public class BlockController {
         }
     }
 
-    @PostMapping("/comment")
+    @PostMapping("/letter-room")
     public BaseResponse<?> blockLetterRoom(@RequestHeader("Authorization") Long loginId,
                                         @RequestBody BlockReqDto reqDto) {
         try {

--- a/unibond/src/main/java/com/unibond/unibond/block/domain/LetterBlock.java
+++ b/unibond/src/main/java/com/unibond/unibond/block/domain/LetterBlock.java
@@ -1,0 +1,38 @@
+package com.unibond.unibond.block.domain;
+
+import com.unibond.unibond.common.BaseEntity;
+import com.unibond.unibond.letter.domain.Letter;
+import com.unibond.unibond.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@DynamicInsert
+@NoArgsConstructor(access = PROTECTED)
+public class LetterBlock extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "reporterId")
+    private Member reporter;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "reportedLetterId")
+    private Letter reportedLetter;
+
+    @Builder
+    public LetterBlock(Member reporter, Letter reportedLetter) {
+        this.reporter = reporter;
+        this.reportedLetter = reportedLetter;
+    }
+}

--- a/unibond/src/main/java/com/unibond/unibond/block/domain/LetterRoomBlock.java
+++ b/unibond/src/main/java/com/unibond/unibond/block/domain/LetterRoomBlock.java
@@ -1,0 +1,38 @@
+package com.unibond.unibond.block.domain;
+
+import com.unibond.unibond.common.BaseEntity;
+import com.unibond.unibond.letter_room.domain.LetterRoom;
+import com.unibond.unibond.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@DynamicInsert
+@NoArgsConstructor(access = PROTECTED)
+public class LetterRoomBlock extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "reporterId")
+    private Member reporter;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "reportedLetterRoomId")
+    private LetterRoom reportedLetterRoom;
+
+    @Builder
+    public LetterRoomBlock(Member reporter, LetterRoom reportedLetterRoom) {
+        this.reporter = reporter;
+        this.reportedLetterRoom = reportedLetterRoom;
+    }
+}

--- a/unibond/src/main/java/com/unibond/unibond/block/dto/BlockReqDto.java
+++ b/unibond/src/main/java/com/unibond/unibond/block/dto/BlockReqDto.java
@@ -1,10 +1,10 @@
 package com.unibond.unibond.block.dto;
 
-import com.unibond.unibond.block.domain.CommentBlock;
-import com.unibond.unibond.block.domain.MemberBlock;
-import com.unibond.unibond.block.domain.PostBlock;
+import com.unibond.unibond.block.domain.*;
 import com.unibond.unibond.comment.domain.Comment;
 import com.unibond.unibond.common.BaseException;
+import com.unibond.unibond.letter.domain.Letter;
+import com.unibond.unibond.letter_room.domain.LetterRoom;
 import com.unibond.unibond.member.domain.Member;
 import com.unibond.unibond.post.domain.Post;
 import lombok.AllArgsConstructor;
@@ -20,6 +20,8 @@ public class BlockReqDto {
     private Long blockedMemberId;
     private Long blockedPostId;
     private Long blockedCommentId;
+    private Long blockedLetterId;
+    private Long blockedLetterRoomId;
 
     public MemberBlock toEntity(Member reporter, Member respondent) {
         return MemberBlock.builder()
@@ -39,6 +41,20 @@ public class BlockReqDto {
         return CommentBlock.builder()
                 .reporter(reporter)
                 .reportedComment(reportedComment)
+                .build();
+    }
+
+    public LetterBlock toEntity(Member reporter, Letter reportedLetter) {
+        return LetterBlock.builder()
+                .reporter(reporter)
+                .reportedLetter(reportedLetter)
+                .build();
+    }
+
+    public LetterRoomBlock toEntity(Member reporter, LetterRoom reportedLetterRoom) {
+        return LetterRoomBlock.builder()
+                .reporter(reporter)
+                .reportedLetterRoom(reportedLetterRoom)
                 .build();
     }
 }

--- a/unibond/src/main/java/com/unibond/unibond/block/repository/LetterBlockRepository.java
+++ b/unibond/src/main/java/com/unibond/unibond/block/repository/LetterBlockRepository.java
@@ -2,8 +2,14 @@ package com.unibond.unibond.block.repository;
 
 import com.unibond.unibond.block.domain.LetterBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LetterBlockRepository extends JpaRepository<LetterBlock, Long> {
+    @Query("select count (lb) > 0 from LetterBlock lb " +
+            "where lb.reporter.id = :reporterId and lb.reportedLetter.id = :reportedLetterId ")
+    Boolean existsByReporterIdAndReportedLetterId(@Param("reporterId") Long reporterId,
+                                                  @Param("reportedLetterId") Long reportedLetterId);
 }

--- a/unibond/src/main/java/com/unibond/unibond/block/repository/LetterBlockRepository.java
+++ b/unibond/src/main/java/com/unibond/unibond/block/repository/LetterBlockRepository.java
@@ -1,0 +1,9 @@
+package com.unibond.unibond.block.repository;
+
+import com.unibond.unibond.block.domain.LetterBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LetterBlockRepository extends JpaRepository<LetterBlock, Long> {
+}

--- a/unibond/src/main/java/com/unibond/unibond/block/repository/LetterRoomBlockRepository.java
+++ b/unibond/src/main/java/com/unibond/unibond/block/repository/LetterRoomBlockRepository.java
@@ -2,8 +2,14 @@ package com.unibond.unibond.block.repository;
 
 import com.unibond.unibond.block.domain.LetterRoomBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LetterRoomBlockRepository extends JpaRepository<LetterRoomBlock, Long> {
+    @Query("select count (lb) > 0 from LetterRoomBlock lb " +
+            "where lb.reporter.id = :reporterId and lb.reportedLetterRoom.id = :reportedLetterRoomId ")
+    Boolean existsByReporterIdAndReportedLetterRoomId(@Param("reporterId") Long reporterId,
+                                                      @Param("reportedLetterRoomId") Long reportedLetterRoomId);
 }

--- a/unibond/src/main/java/com/unibond/unibond/block/repository/LetterRoomBlockRepository.java
+++ b/unibond/src/main/java/com/unibond/unibond/block/repository/LetterRoomBlockRepository.java
@@ -1,0 +1,9 @@
+package com.unibond.unibond.block.repository;
+
+import com.unibond.unibond.block.domain.LetterRoomBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LetterRoomBlockRepository extends JpaRepository<LetterRoomBlock, Long> {
+}

--- a/unibond/src/main/java/com/unibond/unibond/block/service/BlockService.java
+++ b/unibond/src/main/java/com/unibond/unibond/block/service/BlockService.java
@@ -1,17 +1,17 @@
 package com.unibond.unibond.block.service;
 
-import com.unibond.unibond.block.domain.CommentBlock;
-import com.unibond.unibond.block.domain.MemberBlock;
-import com.unibond.unibond.block.domain.PostBlock;
+import com.unibond.unibond.block.domain.*;
 import com.unibond.unibond.block.dto.BlockReqDto;
-import com.unibond.unibond.block.repository.CommentBlockRepository;
-import com.unibond.unibond.block.repository.MemberBlockRepository;
-import com.unibond.unibond.block.repository.PostBlockRepository;
+import com.unibond.unibond.block.repository.*;
 import com.unibond.unibond.comment.domain.Comment;
 import com.unibond.unibond.comment.repository.CommentRepository;
 import com.unibond.unibond.common.BaseException;
 import com.unibond.unibond.common.BaseResponseStatus;
 import com.unibond.unibond.common.service.LoginInfoService;
+import com.unibond.unibond.letter.domain.Letter;
+import com.unibond.unibond.letter.repository.LetterRepository;
+import com.unibond.unibond.letter_room.domain.LetterRoom;
+import com.unibond.unibond.letter_room.repository.LetterRoomRepository;
 import com.unibond.unibond.member.domain.Member;
 import com.unibond.unibond.member.repository.MemberRepository;
 import com.unibond.unibond.post.domain.Post;
@@ -29,12 +29,18 @@ import static com.unibond.unibond.common.BaseResponseStatus.*;
 @RequiredArgsConstructor
 public class BlockService {
     private final LoginInfoService loginInfoService;
+
     private final MemberBlockRepository memberBlockRepository;
     private final PostBlockRepository postBlockRepository;
     private final CommentBlockRepository commentBlockRepository;
+    private final LetterBlockRepository letterBlockRepository;
+    private final LetterRoomBlockRepository letterRoomBlockRepository;
+
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final LetterRepository letterRepository;
+    private final LetterRoomRepository letterRoomRepository;
 
     @Transactional
     public BaseResponseStatus blockMember(BlockReqDto reqDto) throws BaseException {
@@ -60,6 +66,39 @@ public class BlockService {
             Post post = findPost(reqDto.getBlockedPostId());
             PostBlock postBlock = reqDto.toEntity(reporter, post);
             postBlockRepository.save(postBlock);
+            return SUCCESS;
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    @Transactional
+    public BaseResponseStatus blockLetter(BlockReqDto reqDto) throws BaseException {
+        try {
+            Member reporter = loginInfoService.getLoginMember();
+            if (reqDto.getBlockedLetterId() == null) throw new BaseException(NULL_PROPERTY);
+            Letter letter = findLetter(reqDto.getBlockedLetterId());
+            LetterBlock letterBlock = reqDto.toEntity(reporter, letter);
+            letterBlockRepository.save(letterBlock);
+            return SUCCESS;
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    @Transactional
+    public BaseResponseStatus blockLetterRoom(BlockReqDto reqDto) throws BaseException {
+        try {
+            Member reporter = loginInfoService.getLoginMember();
+            if (reqDto.getBlockedLetterRoomId() == null) throw new BaseException(NULL_PROPERTY);
+            LetterRoom letterRoom = findLetterRoom(reqDto.getBlockedLetterRoomId());
+            LetterRoomBlock letterRoomBlock = reqDto.toEntity(reporter, letterRoom);
+            blockLetters(reporter, letterRoom);
+            letterRoomBlockRepository.save(letterRoomBlock);
             return SUCCESS;
         } catch (BaseException e) {
             throw e;
@@ -99,6 +138,21 @@ public class BlockService {
         }
     }
 
+    private void blockLetters(Member reporter, LetterRoom letterRoom) {
+        List<Letter> letterList = letterRoom.getLetterList();
+        if (!letterList.isEmpty()) {
+            List<LetterBlock> letterBlockList = letterList.stream().map(
+                    letter -> LetterBlock.builder()
+                            .reporter(reporter)
+                            .reportedLetter(letter)
+                            .build()
+            ).collect(Collectors.toList());
+
+            letterBlockRepository.saveAll(letterBlockList);
+        }
+
+    }
+
     private Member findMember(Long memberId) throws BaseException {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new BaseException(INVALID_MEMBER_ID));
@@ -112,5 +166,15 @@ public class BlockService {
     private Comment findComment(Long commentId) throws BaseException {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new BaseException(INVALID_COMMENT_ID));
+    }
+
+    private Letter findLetter(Long letterId) throws BaseException {
+        return letterRepository.findById(letterId)
+                .orElseThrow(() -> new BaseException(INVALID_LETTER_ID));
+    }
+
+    private LetterRoom findLetterRoom(Long letterRoomId) throws BaseException {
+        return letterRoomRepository.findById(letterRoomId)
+                .orElseThrow(() -> new BaseException(INVALID_LETTER_ROOM_ID));
     }
 }

--- a/unibond/src/main/java/com/unibond/unibond/common/BaseResponseStatus.java
+++ b/unibond/src/main/java/com/unibond/unibond/common/BaseResponseStatus.java
@@ -79,7 +79,7 @@ public enum BaseResponseStatus {
 
     // letter_room (3400 ~ 3499)
     NOT_YOUR_LETTER_ROOM(false, 3400, "해당 편지함에 접근할 권한이 없습니다."),
-    BLOCKED_LETTER_ROOM(false, 3401, "차단된 편지함입니다.."),
+    BLOCKED_LETTER_ROOM(false, 3401, "차단된 편지함입니다."),
 
     // member (3500 ~ 3599)
     BLOCKED_MEMBER(false, 3500, "차단한 사용자입니다."),

--- a/unibond/src/main/java/com/unibond/unibond/common/BaseResponseStatus.java
+++ b/unibond/src/main/java/com/unibond/unibond/common/BaseResponseStatus.java
@@ -75,10 +75,11 @@ public enum BaseResponseStatus {
     NOT_YOUR_LETTER(false, 3301, "해당 편지를 접근할 권한이 없습니다."),
     CANT_SEND_LETTER(false, 3302, "아직 한 시간이 지나지 않았으므로 편지를 또 다시 보낼 수 없습니다."),
     NOT_YET_ARRIVED(false, 3303, "아직 도착하지 않은 편지입니다."),
-    BLOCKED_LETTER(false, 3304, "차단한 사용자이므로 편지를 주고 받거나 조회할 수 없습니다."),
+    BLOCKED_LETTER(false, 3304, "차단된 편지입니다."),
 
     // letter_room (3400 ~ 3499)
-    NOT_YOUR_LETTER_ROOM(false, 3400, "해당 편지방에 접근할 권한이 없습니다."),
+    NOT_YOUR_LETTER_ROOM(false, 3400, "해당 편지함에 접근할 권한이 없습니다."),
+    BLOCKED_LETTER_ROOM(false, 3401, "차단된 편지함입니다.."),
 
     // member (3500 ~ 3599)
     BLOCKED_MEMBER(false, 3500, "차단한 사용자입니다."),

--- a/unibond/src/main/java/com/unibond/unibond/letter_room/repository/LetterRoomCustomRepository.java
+++ b/unibond/src/main/java/com/unibond/unibond/letter_room/repository/LetterRoomCustomRepository.java
@@ -23,8 +23,12 @@ public interface LetterRoomCustomRepository extends JpaRepository<LetterRoom, Lo
                     "letterRoom.id as letterRoomId " +
             "from letter_room as letterRoom " +
             "left join member_block on  ( " +
-                    "( letterRoom.member_id1 = :member and letterRoom.member_id1 = member_block.reporter_id and letterRoom.member_id2 = member_block.respondent_id ) or " +
-                    "( letterRoom.member_id2 = :member and letterRoom.member_id2 = member_block.reporter_id and letterRoom.member_id1 = member_block.respondent_id ) " +
+                    "( letterRoom.member_id1 = :member and member_block.reporter_id = :member and letterRoom.member_id2 = member_block.respondent_id ) or " +
+                    "( letterRoom.member_id2 = :member and member_block.reporter_id = :member and letterRoom.member_id1 = member_block.respondent_id ) " +
+                    ") " +
+            "left join letter_room_block on ( " +
+                    "( letterRoom.member_id1 = :member and letter_room_block.reporter_id = :member and letterRoom.id = letter_room_block.reported_letter_room_id ) or " +
+                    "( letterRoom.member_id2 = :member and letter_room_block.reporter_id = :member and letterRoom.id = letter_room_block.reported_letter_room_id ) " +
                     ") " +
             "join letter on letterRoom.id = letter.letter_room_id " +
             "join member member1 on member1.id = letterRoom.member_id1 " +
@@ -32,7 +36,7 @@ public interface LetterRoomCustomRepository extends JpaRepository<LetterRoom, Lo
             "where ((member1.id = :member) or (member2.id = :member)) " +
                 "and letterRoom.status = 'ACTIVE' " +
                 "and ((letter.letter_status = 'ARRIVED') or letter.sender_id = :member) " +
-                "and member_block.id IS NULL " +
+                "and member_block.id IS NULL and letter_room_block.id IS NULL " +
             "group by letterRoom.id, member1.id, member2.id " +
             "order by recentLetterCreatedDate desc ",
             nativeQuery = true)


### PR DESCRIPTION
## 📒 개요

편지와 편지함 차단 API

## 📍 Issue 번호

> #61 

## 🛠️ 작업사항

- [x] 편지 차단 API
  - 편지 조회 불가능
  - 편지함 상세 조회에서 제외됨
  - 좋아함에서 제외됨
- [x] 편지함 차단 API 
  - 편지함 상세 조회 불가능
  - 편지함 페이지에서 아예 제외됨
